### PR TITLE
Try to fix "last commit since deploy" mess up

### DIFF
--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -154,7 +154,7 @@ class Stage < ActiveRecord::Base
 
   def github_compare_url
     return unless github_path = project.configuration_parameters.find_by_name("github").try(:value)
-    return unless previous_deployment = deployments.first(:conditions => ["created_at <= ? AND task IN (?) AND status = ?", Time.now, Deployment::DEPLOY_TASKS, Deployment::STATUS_SUCCESS], :order => "id DESC")
+    return unless previous_deployment = deployments.first(:conditions => ["branch = 'master' AND created_at <= ? AND task IN (?) AND status = ?", Time.now, Deployment::DEPLOY_TASKS, Deployment::STATUS_SUCCESS], :order => "id DESC")
     branch = project.configuration_parameters.find_by_name("branch").try(:value) || "master"
     "https://github.com/#{github_path}/compare/#{previous_deployment.revision}...#{branch}"
   end

--- a/db/migrate/20150128032106_add_branch_to_deployment.rb
+++ b/db/migrate/20150128032106_add_branch_to_deployment.rb
@@ -1,0 +1,9 @@
+class AddBranchToDeployment < ActiveRecord::Migration
+  def self.up
+    add_column :deployments, :branch, :string, :default => "master", :null => false
+  end
+
+  def self.down
+    remove_column :deployments, :branch
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150122045734) do
+ActiveRecord::Schema.define(:version => 20150128032106) do
 
   create_table "configuration_parameters", :force => true do |t|
     t.string   "name"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(:version => 20150122045734) do
     t.string   "revision"
     t.integer  "pid"
     t.string   "status",            :default => "running"
+    t.string   "branch",            :default => "master",  :null => false
   end
 
   add_index "deployments", ["stage_id"], :name => "index_deployments_on_stage_id"

--- a/lib/webistrano/deployer.rb
+++ b/lib/webistrano/deployer.rb
@@ -86,6 +86,7 @@ module Webistrano
     # save the revision in the DB if possible
     def save_revision(config)
       if config.fetch(:real_revision)
+        @deployment.branch = @deployment.prompt_config["branch"] || "master"
         @deployment.revision = config.fetch(:real_revision)
         @deployment.save!
       end


### PR DESCRIPTION
We will store the branch of deployment, then we generate "Commits since
last deploy" URL based on last master deployment instead of naive last
deployment. This way, non-master deloyment won't mess up the diff URL
