### PR TITLE
Use previous deployment branch value as repeat default branch value

### DIFF
--- a/app/controllers/deployments_controller.rb
+++ b/app/controllers/deployments_controller.rb
@@ -30,6 +30,8 @@ class DeploymentsController < ApplicationController
   # GET /projects/1/stages/1/deployments/new
   def new
     @deployment = @stage.deployments.new
+    @previous_deployment_branch = @stage.deployments.find_by_id(params[:repeat]).try(:branch) if params[:repeat]
+
     @deployment.task = params[:task]
 
     # Allow description to be passed in via a URL parameter

--- a/app/views/deployments/new.html.erb
+++ b/app/views/deployments/new.html.erb
@@ -24,7 +24,11 @@
     <% @stage.prompt_configurations.each do |conf| %>
       <p>
         <b>Config: <%=h conf.name %></b><br />
-        <input type="<%=h input_type(conf.name) %>" id="deployment_prompt_config_<%=h conf.name %>" name="deployment[prompt_config][<%=h conf.name %>]" style="width:330px;" value="<%=h @deployment.prompt_config[conf.name.to_sym] || conf.value %>" />
+        <% if conf.name == "branch" && @previous_deployment_branch %>
+          <input type="<%=h input_type(conf.name) %>" id="deployment_prompt_config_<%=h conf.name %>" name="deployment[prompt_config][<%=h conf.name %>]" style="width:330px;" value="<%=h @previous_deployment_branch %>" />
+        <% else %>
+          <input type="<%=h input_type(conf.name) %>" id="deployment_prompt_config_<%=h conf.name %>" name="deployment[prompt_config][<%=h conf.name %>]" style="width:330px;" value="<%=h @deployment.prompt_config[conf.name.to_sym] || conf.value %>" />
+        <% end %>
       </p>
     <% end %>
   <% end %>


### PR DESCRIPTION
It is more convenient for us to use previous branch configuration to deploy.
